### PR TITLE
fix: move typescript to production dependencies

### DIFF
--- a/express/backend/package-lock.json
+++ b/express/backend/package-lock.json
@@ -3702,8 +3702,7 @@
     "typescript": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
-      "dev": true
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA=="
     },
     "undefsafe": {
       "version": "2.0.3",

--- a/express/backend/package.json
+++ b/express/backend/package.json
@@ -25,6 +25,7 @@
 		"node-cache": "^5.1.2",
 		"rimraf": "^3.0.2",
 		"tweetsodium": "0.0.5",
+		"typescript": "^4.4.3",
 		"universal-cookie-express": "^4.0.3",
 		"uuid": "^8.3.2",
 		"ws": "^7.5.3"
@@ -42,7 +43,6 @@
 		"@types/uuid": "^8.3.1",
 		"@types/ws": "^7.4.7",
 		"nodemon": "^2.0.13",
-		"ts-node": "^10.3.0",
-		"typescript": "^4.4.3"
+		"ts-node": "^10.3.0"
 	}
 }


### PR DESCRIPTION
I'm not 100% sure that this will fix our issue, since I somehow cannot login in the docker container, and login is required to download a zip file.
But this
https://github.com/ioBroker/dev-portal/blob/79ffd9b22d12e7256e30cb63b9038de562d8a3da/express/Dockerfile#L41-L42
looks like `typescript` gets removed from the image, although it is actually used in production.

On the other hand, `typescript` is a production dependency of `create-adapter`, so maybe this is just npm being weird?